### PR TITLE
Reduce Schmooze instance variable footprint

### DIFF
--- a/lib/schmooze/base.rb
+++ b/lib/schmooze/base.rb
@@ -62,16 +62,19 @@ module Schmooze
       end
 
       def spawn_process
-        process_data = Open3.popen3(
+        stdin, stdout, stderr, process_thread = Open3.popen3(
           @_schmooze_env,
           'node',
           '-e',
           @_schmooze_code,
           chdir: @_schmooze_root
         )
-        ensure_packages_are_initiated(*process_data)
-        ObjectSpace.define_finalizer(self, self.class.send(:finalize, *process_data))
-        @_schmooze_stdin, @_schmooze_stdout, @_schmooze_stderr, @_schmooze_process_thread = process_data
+        ensure_packages_are_initiated(stdin, stdout, stderr, process_thread)
+        ObjectSpace.define_finalizer(self, self.class.send(:finalize, stdin, stdout, stderr, process_thread))
+        @_schmooze_stdin = stdin
+        @_schmooze_stdout = stdout
+        @_schmooze_stderr = stderr
+        @_schmooze_process_thread = process_thread
       end
 
       def ensure_packages_are_initiated(stdin, stdout, stderr, process_thread)

--- a/lib/schmooze/base.rb
+++ b/lib/schmooze/base.rb
@@ -54,7 +54,7 @@ module Schmooze
     end
 
     def pid
-      @_schmooze_bridge.process_thread && @_schmooze_bridge.process_thread.pid
+      @_schmooze_bridge.process_thread_pid
     end
 
     private
@@ -102,6 +102,10 @@ module Schmooze
         @env = env
         @root = root
         @code = code
+      end
+
+      def process_thread_pid
+        process_thread && process_thread.pid
       end
 
       def spawn_process(klass)

--- a/lib/schmooze/base.rb
+++ b/lib/schmooze/base.rb
@@ -43,7 +43,10 @@ module Schmooze
     def initialize(root, env={})
       @_schmooze_env = env
       @_schmooze_root = root
-      @_schmooze_code = ProcessorGenerator.generate(self.class.instance_variable_get(:@_schmooze_imports) || [], self.class.instance_variable_get(:@_schmooze_methods) || [])
+      @_schmooze_code = ProcessorGenerator.generate(
+        self.class.instance_variable_get(:@_schmooze_imports) || [],
+        self.class.instance_variable_get(:@_schmooze_methods) || []
+      )
     end
 
     def pid
@@ -87,12 +90,14 @@ module Schmooze
               package = JSON.parse(File.read(package_json_path))
               %w(dependencies devDependencies).each do |key|
                 if package.has_key?(key) && package[key].has_key?(package_name)
-                  raise Schmooze::DependencyError, "Cannot find module '#{package_name}'. The module was found in '#{package_json_path}' however, please run 'npm install' from '#{@_schmooze_root}'"
+                  raise Schmooze::DependencyError, "Cannot find module '#{package_name}'. The module was found in "\
+                    "'#{package_json_path}' however, please run 'npm install' from '#{@_schmooze_root}'"
                 end
               end
             rescue Errno::ENOENT
             end
-            raise Schmooze::DependencyError, "Cannot find module '#{package_name}'. You need to add it to '#{package_json_path}' and run 'npm install'"
+            raise Schmooze::DependencyError, "Cannot find module '#{package_name}'. You need to add it to "\
+              "'#{package_json_path}' and run 'npm install'"
           else
             raise Schmooze::Error, error_message
           end

--- a/test/schmooze_test.rb
+++ b/test/schmooze_test.rb
@@ -32,7 +32,7 @@ class SchmoozeTest < Minitest::Test
   end
 
   def test_it_generates_code
-    assert_equal <<-JS.strip, @schmoozer.instance_variable_get(:@_schmooze_code).strip
+    assert_equal <<-JS.strip, @schmoozer.instance_variable_get(:@_schmooze_bridge).code.strip
 try {
   var coffee = require("coffee-script");
   var compile = require("coffee-script").compile;


### PR DESCRIPTION
The change made in https://github.com/Shopify/schmooze/commit/c4a5d35239b9214ff0f4a10471959c17dabb0d02 is a great improvement, but I noticed that we could pretty easily reduce the number of instance variables reserved by `Schmooze::Base` to just two (one at the class level and one at the instance level) if we scope everything inside two internal objects. That's what I set out to do in commits https://github.com/Shopify/schmooze/compare/960d26f9cbffa3c6860758d8017aac272fc3c670~...4035e45ac8bd50f4469f7b8ee6029871fd16bfe2. After doing that, the structure of the code revealed that some of the existing methods were a better fit in the new `Bridge` class, so I pushed them down (commits https://github.com/Shopify/schmooze/compare/686b0142652f4b62f6c41c5579f3d23aa61f486d~...9506e67e19f1d9d37d8a8a08e355d967f977ffb7).

Let me know what you think of this and thanks for creating this gem.