### PR TITLE
Initialize @_schmooze_process_thread in ctor

### DIFF
--- a/lib/schmooze/base.rb
+++ b/lib/schmooze/base.rb
@@ -41,6 +41,7 @@ module Schmooze
     end
 
     def initialize(root, env={})
+      @_schmooze_process_thread = nil
       @_schmooze_env = env
       @_schmooze_root = root
       @_schmooze_code = ProcessorGenerator.generate(self.class.instance_variable_get(:@_schmooze_imports) || [], self.class.instance_variable_get(:@_schmooze_methods) || [])


### PR DESCRIPTION
This avoids generating a warning when schmooze is used within tests that highlight access of fields before they are initialized