### PR TITLE
Added ability to specify nodejs executable path

### DIFF
--- a/lib/schmooze/base.rb
+++ b/lib/schmooze/base.rb
@@ -59,7 +59,7 @@ module Schmooze
       def spawn_process
         process_data = Open3.popen3(
           @_schmooze_env,
-          'node',
+          ENV.fetch('NODEJS_EXECUTABLE_PATH', 'node'),
           '-e',
           @_schmooze_code,
           chdir: @_schmooze_root


### PR DESCRIPTION
Sometimes (like on ubuntu 14.04) node is not in path or it's nodejs. Or in my case I use nodenv, and soemtimes it does not pick it up. This way, You can specify where node executable is and how to run it.