### PR TITLE
Handle exceptions in the finalizer

### DIFF
--- a/lib/schmooze/base.rb
+++ b/lib/schmooze/base.rb
@@ -34,7 +34,11 @@ module Schmooze
             stdin.close
             stdout.close
             stderr.close
-            Process.kill(0, process_thread.pid)
+            begin
+              Process.kill(0, process_thread.pid)
+            rescue Errno::ESRCH
+              # Process is already dead, so no worries.
+            end
             process_thread.value
           end
         end


### PR DESCRIPTION
Fix:
```
~/gems/schmooze-0.1.6/lib/schmooze/base.rb:37:in `kill': No such process (Errno::ESRCH)
~/gems/schmooze-0.1.6/lib/schmooze/base.rb:37:in `block in finalize'
```

Which prints a warning starting from Ruby 3.1:

```
warning: Exception in finalizer #<Proc:0x00007fcd98bd0ca0 /tmp/bundle/ruby/3.1.0/gems/schmooze-0.1.6/lib/schmooze/base.rb:33>
```

NB: I had to unarchive the repo.